### PR TITLE
renamed usv_sail_plugin filename to correct library name

### DIFF
--- a/usv_sim/xacro/rudderboat.xacro
+++ b/usv_sim/xacro/rudderboat.xacro
@@ -18,7 +18,7 @@
     <!-- Gazebo plugin listens to the body-->
 	
 
-	<plugin name="usv_sail_plugin" filename="libusv_sailing_plugin.so">
+	<plugin name="usv_sail_plugin" filename="libfoil_dynamics_plugin.so">
 		<link_type>rudder</link_type>
 		<mult_lift>1.5</mult_lift>
 		<mult_drag>1</mult_drag>

--- a/usv_sim/xacro/sailboat.xacro
+++ b/usv_sim/xacro/sailboat.xacro
@@ -95,7 +95,7 @@
     <!-- Plugin list -->
   <gazebo>
 
-	<plugin name="usv_sail_plugin" filename="libusv_sailing_plugin.so">
+	<plugin name="usv_sail_plugin" filename="libfoil_dynamics_plugin.so">
 		<link_type>sail</link_type>
 		<a0>0</a0>
 		<cla>3.0</cla>
@@ -116,7 +116,7 @@
       </plugin>
       
   
-      <plugin name="usv_sail_plugin" filename="libusv_sailing_plugin.so">
+      <plugin name="usv_sail_plugin" filename="libfoil_dynamics_plugin.so">
 		  <link_type>keel</link_type>
 		  <a0>0</a0>
 		  <cla>10.0</cla>
@@ -134,7 +134,7 @@
     </plugin>
     
 
-    <plugin name="usv_sail_plugin" filename="libusv_sailing_plugin.so">
+    <plugin name="usv_sail_plugin" filename="libfoil_dynamics_plugin.so">
 		<link_type>rudder</link_type>
 		<a0>0</a0>
 		<cla>0.8</cla>


### PR DESCRIPTION
This commit should resolve issues #27 and #22, the foil dynamics plugin library is installed as "libfoil_dynamics_plugin.so" but the xacro files referred to the non-existing "libusv_sailing_plugin.so" as pointed out by jperk15 